### PR TITLE
Add MarkdownParser interface to enable support for multiple markdown …

### DIFF
--- a/src/info/opencards/md/MarkdownParser.java
+++ b/src/info/opencards/md/MarkdownParser.java
@@ -1,0 +1,20 @@
+package info.opencards.md;
+
+import info.opencards.core.CardFile;
+
+import java.util.List;
+
+/**
+ * It defines methods needed to parse a markdown file into a set of {@link MarkdownFlashcard}.
+ * It was added to allow parsing of different markdown file formats.
+ */
+public interface MarkdownParser {
+
+    /**
+     * It parses the mardkdown source file from provided {@link CardFile} into a list of {@link MarkdownFlashcard}
+     *
+     * @param cardFile file to be parsed
+     * @return A list of {@link MarkdownFlashcard}
+     */
+    List<MarkdownFlashcard> parse(CardFile cardFile);
+}

--- a/src/info/opencards/md/MarkdownParser.kt
+++ b/src/info/opencards/md/MarkdownParser.kt
@@ -1,6 +1,7 @@
 package info.opencards.md
 
 import info.opencards.Utils
+import info.opencards.core.CardFile
 import info.opencards.ui.preferences.AdvancedSettings.*
 import org.intellij.markdown.ast.ASTNode
 import org.intellij.markdown.flavours.gfm.GFMFlavourDescriptor
@@ -99,3 +100,10 @@ internal fun readFile(path: String, encoding: Charset): String {
     return String(encoded, encoding)
 }
 
+class DefaultMarkdownParser : info.opencards.md.MarkdownParser {
+
+    override fun parse(cardFile: CardFile): List<MarkdownFlashcard> {
+        return parseMD(cardFile.fileLocation, cardFile.properties.isUseMarkdownSelector);
+    }
+
+}

--- a/src/info/opencards/md/MarkdownParserFactory.java
+++ b/src/info/opencards/md/MarkdownParserFactory.java
@@ -1,0 +1,12 @@
+package info.opencards.md;
+
+/**
+ * It creates the selected {@link MarkdownParser}
+ */
+public class MarkdownParserFactory {
+
+    public static MarkdownParser create() {
+        return new DefaultMarkdownParser();
+    }
+
+}

--- a/src/info/opencards/md/MdSlideManager.java
+++ b/src/info/opencards/md/MdSlideManager.java
@@ -140,7 +140,8 @@ public class MdSlideManager extends AbstractSlideManager {
     public void openCardFile(CardFile cardFile) {
         cardFile.synchronize();
 
-        slides = MarkdownParserKt.parseMD(cardFile.getFileLocation(), cardFile.getProperties().useMarkdownSelector());
+        MarkdownParser markdownParser = MarkdownParserFactory.create();
+        slides = markdownParser.parse(cardFile);
 
 
         jfxPanel = new JFXPanel();

--- a/src/info/opencards/pptintegration/PPTSerializer.java
+++ b/src/info/opencards/pptintegration/PPTSerializer.java
@@ -7,7 +7,8 @@ import info.opencards.core.FlashCard;
 import info.opencards.core.FlashCardCollection;
 import info.opencards.core.LearnStatusSerializer;
 import info.opencards.md.MarkdownFlashcard;
-import info.opencards.md.MarkdownParserKt;
+import info.opencards.md.MarkdownParser;
+import info.opencards.md.MarkdownParserFactory;
 import info.opencards.util.InvalidCardFileFormatException;
 import org.apache.poi.hslf.usermodel.HSLFSlide;
 import org.apache.poi.hslf.usermodel.HSLFSlideShow;
@@ -48,8 +49,8 @@ public class PPTSerializer implements LearnStatusSerializer {
 
 
             } else if (cardFile.getFileLocation().getName().endsWith(".md")) {
-                boolean useSelector = cardFile.getProperties().useMarkdownSelector();
-                List<MarkdownFlashcard> flashcards = MarkdownParserKt.parseMD(cardFile.getFileLocation(), useSelector);
+                MarkdownParser markdownParser = MarkdownParserFactory.create();
+                List<MarkdownFlashcard> flashcards = markdownParser.parse(cardFile);
 
                 for (int i = 0; i < flashcards.size(); i++) {
                     MarkdownFlashcard card = flashcards.get(i);


### PR DESCRIPTION
I would like to have support for multiple markdown parsers. I created a small change in personal fork of this  project to have a start for a conversation on this subject. It would be nice to be able to put a jar with a different markdown parser implementation in a common place and then on opencards start to be able to select it.